### PR TITLE
Support building foci

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -1,0 +1,220 @@
+package builder
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type BuilderEngineType int
+
+const (
+	BuilderEngineTypeOverlayBD BuilderEngineType = iota
+	BuilderEngineTypeFOCI
+)
+
+type Builder interface {
+	Build(ctx context.Context) error
+}
+
+type BuilderOptions struct {
+	Ref       string
+	TargetRef string
+	Auth      string
+	PlainHTTP bool
+	WorkDir   string
+	Engine    BuilderEngineType
+}
+
+type overlaybdBuilder struct {
+	layers int
+	engine builderEngine
+}
+
+type builderEngine interface {
+	downloadLayer(ctx context.Context, idx int) error
+
+	// build layer archive, maybe tgz or zfile
+	buildLayer(ctx context.Context, idx int) error
+
+	uploadLayer(ctx context.Context, idx int) error
+
+	// UploadImage upload new manifest and config
+	uploadImage(ctx context.Context) error
+
+	// cleanup remove workdir
+	cleanup()
+}
+
+type builderEngineBase struct {
+	fetcher  remotes.Fetcher
+	pusher   remotes.Pusher
+	manifest specs.Manifest
+	config   specs.Image
+	workDir  string
+}
+
+func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, error) {
+	resolver := docker.NewResolver(docker.ResolverOptions{
+		Credentials: func(s string) (string, string, error) {
+			if opt.Auth == "" {
+				return "", "", nil
+			}
+			authSplit := strings.Split(opt.Auth, ":")
+			return authSplit[0], authSplit[1], nil
+		},
+		PlainHTTP: opt.PlainHTTP,
+	})
+	engineBase, err := getBuilderEngineBase(ctx, resolver, opt.Ref, opt.TargetRef)
+	if err != nil {
+		return nil, err
+	}
+	engineBase.workDir = opt.WorkDir
+	var engine builderEngine
+	switch opt.Engine {
+	case BuilderEngineTypeOverlayBD:
+		engine = NewOverlayBDBuilderEngine(engineBase)
+	case BuilderEngineTypeFOCI:
+		engine = NewFOCIBuilderEngine(engineBase)
+	}
+	return &overlaybdBuilder{
+		layers: len(engineBase.manifest.Layers),
+		engine: engine,
+	}, nil
+}
+
+// TODO speed up with async
+func (b *overlaybdBuilder) Build(ctx context.Context) error {
+	defer b.engine.cleanup()
+	downloaded := make([]chan error, b.layers)
+	converted := make([]chan error, b.layers)
+	var uploaded sync.WaitGroup
+
+	errCh := make(chan error)
+	defer close(errCh)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// collect error and kill all builder goroutines
+	var retErr error
+	retErr = nil
+	go func() {
+		select {
+		case <-ctx.Done():
+		case retErr = <-errCh:
+		}
+		if retErr != nil {
+			cancel()
+		}
+	}()
+
+	for i := 0; i < b.layers; i++ {
+		downloaded[i] = make(chan error)
+		converted[i] = make(chan error)
+
+		// download goroutine
+		go func(idx int) {
+			defer close(downloaded[idx])
+			if err := b.engine.downloadLayer(ctx, idx); err != nil {
+				contextSendChan(ctx, errCh, errors.Wrapf(err, "failed to download layer %d", idx))
+				return
+			}
+			logrus.Infof("downloaded layer %d", idx)
+			contextSendChan(ctx, downloaded[idx], nil)
+		}(i)
+
+		// convert goroutine
+		go func(idx int) {
+			defer close(converted[idx])
+			if contextReceiveChan(ctx, downloaded[idx]); ctx.Err() != nil {
+				return
+			}
+			if idx > 0 {
+				if contextReceiveChan(ctx, converted[idx-1]); ctx.Err() != nil {
+					return
+				}
+			}
+			if err := b.engine.buildLayer(ctx, idx); err != nil {
+				contextSendChan(ctx, errCh, errors.Wrapf(err, "failed to convert layer %d", idx))
+				return
+			}
+			logrus.Infof("layer %d converted", idx)
+			// send to upload(idx) and convert(idx+1) once each
+			contextSendChan(ctx, converted[idx], nil)
+			if idx+1 < b.layers {
+				contextSendChan(ctx, converted[idx], nil)
+			}
+		}(i)
+
+		// upload goroutine
+		uploaded.Add(1)
+		go func(idx int) {
+			defer uploaded.Done()
+			if contextReceiveChan(ctx, converted[idx]); ctx.Err() != nil {
+				return
+			}
+			if err := b.engine.uploadLayer(ctx, idx); err != nil {
+				contextSendChan(ctx, errCh, errors.Wrapf(err, "failed to upload layer %d", idx))
+				return
+			}
+			logrus.Infof("layer %d uploaded", idx)
+		}(i)
+	}
+	uploaded.Wait()
+	if retErr != nil {
+		return retErr
+	}
+
+	if err := b.engine.uploadImage(ctx); err != nil {
+		return errors.Wrap(err, "failed to upload manifest or config")
+	}
+	logrus.Info("convert finished")
+	return nil
+}
+
+func getBuilderEngineBase(ctx context.Context, resolver remotes.Resolver, ref, targetRef string) (*builderEngineBase, error) {
+	_, desc, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve reference %q", ref)
+	}
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get fetcher for %q", ref)
+	}
+	pusher, err := resolver.Pusher(ctx, targetRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get pusher for %q", targetRef)
+	}
+	manifest, config, err := fetchManifestAndConfig(ctx, fetcher, desc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch manifest and config")
+	}
+	return &builderEngineBase{
+		fetcher:  fetcher,
+		pusher:   pusher,
+		manifest: manifest,
+		config:   config,
+	}, nil
+}
+
+// block until ctx.Done() or sended
+func contextSendChan(ctx context.Context, ch chan<- error, value error) {
+	select {
+	case <-ctx.Done():
+	case ch <- value:
+	}
+}
+
+// block until ctx.Done() or received
+func contextReceiveChan(ctx context.Context, ch <-chan error) {
+	select {
+	case <-ctx.Done():
+	case <-ch:
+	}
+}

--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package builder
 
 import (
@@ -16,7 +32,7 @@ type BuilderEngineType int
 
 const (
 	BuilderEngineTypeOverlayBD BuilderEngineType = iota
-	BuilderEngineTypeFOCI
+	BuilderEngineTypeFastOCI
 )
 
 type Builder interface {
@@ -80,8 +96,8 @@ func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, erro
 	switch opt.Engine {
 	case BuilderEngineTypeOverlayBD:
 		engine = NewOverlayBDBuilderEngine(engineBase)
-	case BuilderEngineTypeFOCI:
-		engine = NewFOCIBuilderEngine(engineBase)
+	case BuilderEngineTypeFastOCI:
+		engine = NewFastOCIBuilderEngine(engineBase)
 	}
 	return &overlaybdBuilder{
 		layers: len(engineBase.manifest.Layers),
@@ -89,7 +105,6 @@ func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, erro
 	}, nil
 }
 
-// TODO speed up with async
 func (b *overlaybdBuilder) Build(ctx context.Context) error {
 	defer b.engine.cleanup()
 	downloaded := make([]chan error, b.layers)

--- a/cmd/convertor/builder/builder_utils.go
+++ b/cmd/convertor/builder/builder_utils.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package builder
 
 import (
@@ -225,7 +241,7 @@ func uploadBytes(ctx context.Context, pusher remotes.Pusher, desc specs.Descript
 func buildArchiveFromFiles(ctx context.Context, target string, compress compression.Compression, files ...string) error {
 	archive, err := os.Create(target)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create tgz file: %q")
+		return errors.Wrapf(err, "failed to create tgz file: %q", target)
 	}
 	defer archive.Close()
 	fzip, err := compression.CompressStream(archive, compress)

--- a/cmd/convertor/builder/builder_utils.go
+++ b/cmd/convertor/builder/builder_utils.go
@@ -1,0 +1,271 @@
+package builder
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/continuity"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func fetchManifestAndConfig(ctx context.Context, fetcher remotes.Fetcher, manifestDesc specs.Descriptor) (specs.Manifest, specs.Image, error) {
+	// get manifest
+	rc, err := fetcher.Fetch(ctx, manifestDesc)
+	if err != nil {
+		return specs.Manifest{}, specs.Image{}, errors.Wrapf(err, "failed to fetch manifest")
+	}
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return specs.Manifest{}, specs.Image{}, errors.Wrapf(err, "failed to fetch manifest")
+	}
+	rc.Close()
+	manifest := specs.Manifest{}
+	err = json.Unmarshal(buf, &manifest)
+	if err != nil {
+		return specs.Manifest{}, specs.Image{}, err
+	}
+	// get config
+	rc, err = fetcher.Fetch(ctx, manifest.Config)
+	if err != nil {
+		return specs.Manifest{}, specs.Image{}, errors.Wrapf(err, "failed to fetch config")
+	}
+	buf, err = io.ReadAll(rc)
+	if err != nil {
+		return specs.Manifest{}, specs.Image{}, errors.Wrapf(err, "failed to fetch config")
+	}
+	rc.Close()
+	config := specs.Image{}
+	if err = json.Unmarshal(buf, &config); err != nil {
+		return specs.Manifest{}, specs.Image{}, err
+	}
+	return manifest, config, nil
+}
+
+func uploadManifestAndConfig(ctx context.Context, pusher remotes.Pusher, manifest specs.Manifest, config specs.Image) error {
+	cbuf, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	manifest.Config = specs.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Config,
+		Digest:    digest.FromBytes(cbuf),
+		Size:      (int64)(len(cbuf)),
+	}
+	if err = uploadBytes(ctx, pusher, manifest.Config, cbuf); err != nil {
+		return errors.Wrapf(err, "failed to upload config")
+	}
+
+	cbuf, err = json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	manifestDesc := specs.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Manifest,
+		Digest:    digest.FromBytes(cbuf),
+		Size:      (int64)(len(cbuf)),
+	}
+
+	if err = uploadBytes(ctx, pusher, manifestDesc, cbuf); err != nil {
+		return errors.Wrapf(err, "failed to upload manifest")
+	}
+	return nil
+}
+
+func downloadLayer(ctx context.Context, fetcher remotes.Fetcher, targetFile string, desc specs.Descriptor, decompress bool) error {
+	rc, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return err
+	}
+	dir := path.Dir(targetFile)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	ftar, err := os.Create(targetFile)
+	if err != nil {
+		return err
+	}
+	if decompress {
+		rc, err = compression.DecompressStream(rc)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err = io.Copy(ftar, rc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func prepareWritableLayer(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-create")
+	dataPath := path.Join(dir, "writable_data")
+	indexPath := path.Join(dir, "writable_index")
+	os.RemoveAll(dataPath)
+	os.RemoveAll(indexPath)
+	out, err := exec.CommandContext(ctx, binpath, "-s",
+		dataPath, indexPath, "64").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-create: %s", out)
+	}
+	return nil
+}
+
+// TODO maybe refactor this
+func writeConfig(dir string, configJSON *snapshot.OverlayBDBSConfig) error {
+	data, err := json.Marshal(configJSON)
+	if err != nil {
+		return err
+	}
+
+	confPath := path.Join(dir, "config.json")
+	if err := continuity.AtomicWriteFile(confPath, data, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func overlaybdCommit(ctx context.Context, dir, commitFile string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-commit")
+
+	out, err := exec.CommandContext(ctx, binpath, "-z",
+		path.Join(dir, "writable_data"),
+		path.Join(dir, "writable_index"),
+		path.Join(dir, commitFile)).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-commit: %s", out)
+	}
+	return nil
+}
+
+func getFileDesc(filepath string, decompress bool) (specs.Descriptor, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return specs.Descriptor{}, err
+	}
+	defer file.Close()
+	var rc io.ReadCloser
+	if decompress {
+		rc, err = compression.DecompressStream(file)
+		if err != nil {
+			return specs.Descriptor{}, err
+		}
+	} else {
+		rc = file
+	}
+
+	h := sha256.New()
+	size, err := io.Copy(h, rc)
+	if err != nil {
+		return specs.Descriptor{}, err
+	}
+	dgst := digest.NewDigest(digest.SHA256, h)
+	return specs.Descriptor{
+		Digest: dgst,
+		Size:   size,
+	}, nil
+}
+
+func uploadBlob(ctx context.Context, pusher remotes.Pusher, path string, desc specs.Descriptor) error {
+	cw, err := pusher.Push(ctx, desc)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			logrus.Infof("layer %s exists", desc.Digest.String())
+			return nil
+		}
+		return err
+	}
+
+	defer cw.Close()
+	fobd, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fobd.Close()
+	if err = content.Copy(ctx, cw, fobd, desc.Size, desc.Digest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func uploadBytes(ctx context.Context, pusher remotes.Pusher, desc specs.Descriptor, data []byte) error {
+	cw, err := pusher.Push(ctx, desc)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			logrus.Infof("content %s exists", desc.Digest.String())
+			return nil
+		}
+		return err
+	}
+	defer cw.Close()
+
+	err = content.Copy(ctx, cw, bytes.NewReader(data), desc.Size, desc.Digest)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildArchiveFromFiles(ctx context.Context, target string, compress compression.Compression, files ...string) error {
+	archive, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create tgz file: %q")
+	}
+	defer archive.Close()
+	fzip, err := compression.CompressStream(archive, compress)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create compression %v", compress)
+	}
+	defer fzip.Close()
+	ftar := tar.NewWriter(fzip)
+	defer ftar.Close()
+	for _, file := range files {
+		if err := addFileToArchive(ctx, ftar, file); err != nil {
+			return errors.Wrapf(err, "failed to add file %q to archive %q", file, target)
+		}
+	}
+	return nil
+}
+
+func addFileToArchive(ctx context.Context, ftar *tar.Writer, filepath string) error {
+	file, err := os.Open(filepath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to open file: %q", filepath)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+	if err = ftar.WriteHeader(header); err != nil {
+		return err
+	}
+	_, err = io.Copy(ftar, file)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/convertor/builder/foci_builder.go
+++ b/cmd/convertor/builder/foci_builder.go
@@ -1,0 +1,183 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// labelKeyFOCI contains OCI image layer digests witch the foci index points
+	labelKeyFOCI = "containerd.io/snapshot/overlaybd/fastoci"
+
+	// TODO make foci baselayer compatible with overlaybd
+	fociBaseLayer = "/opt/overlaybd/baselayers/foci-base"
+
+	// index of OCI layers (gzip)
+	gzipMetaFile = "gzip.meta"
+
+	// index of block device
+	fsMetaFile = "ext4.fs.meta"
+
+	// foci index layer (gzip)
+	fociLayerTar = "foci.tar.gz"
+
+	// fociIdentifier is an empty file just used as a identifier
+	fociIdentifier = ".fastoci.overlaybd"
+)
+
+type fociBuilderEngine struct {
+	*builderEngineBase
+	overlaybdConfig *snapshot.OverlayBDBSConfig
+	fociLayers      []specs.Descriptor
+}
+
+func NewFOCIBuilderEngine(base *builderEngineBase) builderEngine {
+	config := &snapshot.OverlayBDBSConfig{
+		Lowers:     []snapshot.OverlayBDBSConfigLower{},
+		ResultFile: "",
+	}
+	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: fociBaseLayer,
+	})
+	return &fociBuilderEngine{
+		builderEngineBase: base,
+		overlaybdConfig:   config,
+		fociLayers:        make([]specs.Descriptor, len(base.manifest.Layers)),
+	}
+}
+
+func (e *fociBuilderEngine) downloadLayer(ctx context.Context, idx int) error {
+	desc := e.manifest.Layers[idx]
+	targetFile := path.Join(e.getLayerDir(idx), "layer.tar")
+	return downloadLayer(ctx, e.fetcher, targetFile, desc, false)
+}
+
+func (e *fociBuilderEngine) buildLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	if err := prepareWritableLayer(ctx, layerDir); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
+		Data:  path.Join(layerDir, "writable_data"),
+		Index: path.Join(layerDir, "writable_index"),
+	}
+	if err := writeConfig(layerDir, e.overlaybdConfig); err != nil {
+		return err
+	}
+	if err := fociApply(ctx, layerDir); err != nil {
+		return err
+	}
+	if err := overlaybdCommit(ctx, layerDir, fsMetaFile); err != nil {
+		return err
+	}
+	// For now, overlaybd-foci-apply generate gzip.meta at workdir
+	// TODO refactor this
+	if err := os.Rename(gzipMetaFile, path.Join(layerDir, gzipMetaFile)); err != nil {
+		return errors.Wrapf(err, "failed to move file %q", gzipMetaFile)
+	}
+	if err := e.createIdentifier(idx); err != nil {
+		return errors.Wrapf(err, "failed to create identifier %q", fociIdentifier)
+	}
+	if err := buildArchiveFromFiles(ctx, path.Join(layerDir, fociLayerTar), compression.Gzip,
+		path.Join(layerDir, fsMetaFile),
+		path.Join(layerDir, gzipMetaFile),
+		path.Join(layerDir, fociIdentifier),
+	); err != nil {
+		return errors.Wrapf(err, "failed to create foci archive for layer %d", idx)
+	}
+	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, snapshot.OverlayBDBSConfigLower{
+		DataFile: path.Join(layerDir, "layer.tar"),
+		File:     path.Join(layerDir, fsMetaFile),
+	})
+	os.Remove(path.Join(layerDir, "writable_data"))
+	os.Remove(path.Join(layerDir, "writable_index"))
+	return nil
+}
+
+func (e *fociBuilderEngine) uploadLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	desc, err := getFileDesc(path.Join(layerDir, fociLayerTar), false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get descriptor for layer %d", idx)
+	}
+	desc.MediaType = specs.MediaTypeImageLayerGzip
+	desc.Annotations = map[string]string{
+		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
+		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+		labelKeyFOCI:                e.manifest.Layers[idx].Digest.String(),
+	}
+	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, fociLayerTar), desc); err != nil {
+		return errors.Wrapf(err, "failed to upload layer %d", idx)
+	}
+	e.fociLayers[idx] = desc
+	return nil
+}
+
+func (e *fociBuilderEngine) uploadImage(ctx context.Context) error {
+	for idx := range e.manifest.Layers {
+		layerDir := e.getLayerDir(idx)
+		uncompress, err := getFileDesc(path.Join(layerDir, fociLayerTar), true)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get uncompressed descriptor for layer %d", idx)
+		}
+		e.manifest.Layers[idx] = e.fociLayers[idx]
+		e.config.RootFS.DiffIDs[idx] = uncompress.Digest
+	}
+	// TODO make foci baselayer compatible with overlaybd
+	baseDesc := specs.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Layer,
+		Digest:    "sha256:936469fc5a3adbac0ae7017a7a5e3fd013950b4d8c1f7acf2924cb7e8cdf3c8d",
+		Size:      784349,
+		Annotations: map[string]string{
+			labelKeyOverlayBDBlobDigest: "sha256:936469fc5a3adbac0ae7017a7a5e3fd013950b4d8c1f7acf2924cb7e8cdf3c8d",
+			labelKeyOverlayBDBlobSize:   "784349",
+		},
+	}
+	if err := uploadBlob(ctx, e.pusher, fociBaseLayer, baseDesc); err != nil {
+		return errors.Wrapf(err, "failed to upload baselayer %q", fociBaseLayer)
+	}
+	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
+	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
+	return uploadManifestAndConfig(ctx, e.pusher, e.manifest, e.config)
+}
+
+func (e fociBuilderEngine) cleanup() {
+	os.RemoveAll(e.workDir)
+}
+
+func (e *fociBuilderEngine) getLayerDir(idx int) string {
+	return path.Join(e.workDir, fmt.Sprintf("%04d_", idx)+e.manifest.Layers[idx].Digest.String())
+}
+
+func (e *fociBuilderEngine) createIdentifier(idx int) error {
+	targetFile := path.Join(e.getLayerDir(idx), fociIdentifier)
+	file, err := os.Create(targetFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create identifier file %q", fociIdentifier)
+	}
+	defer file.Close()
+	return nil
+}
+
+func fociApply(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-foci-apply")
+
+	out, err := exec.CommandContext(ctx, binpath,
+		path.Join(dir, "layer.tar"),
+		path.Join(dir, "config.json")).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-foci-apply: %s", out)
+	}
+	return nil
+}

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -1,0 +1,148 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// labelKeyOverlayBDBlobDigest is the annotation key in the manifest to
+	// describe the digest of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	labelKeyOverlayBDBlobDigest = "containerd.io/snapshot/overlaybd/blob-digest"
+
+	// labelKeyOverlayBDBlobSize is the annotation key in the manifest to
+	// describe the size of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	labelKeyOverlayBDBlobSize = "containerd.io/snapshot/overlaybd/blob-size"
+
+	overlaybdBaseLayer = "/opt/overlaybd/baselayers/ext4_64"
+
+	commitFile = "overlaybd.commit"
+)
+
+type overlaybdBuilderEngine struct {
+	*builderEngineBase
+	overlaybdConfig *snapshot.OverlayBDBSConfig
+	overlaybdLayers []specs.Descriptor
+}
+
+func NewOverlayBDBuilderEngine(base *builderEngineBase) builderEngine {
+	config := &snapshot.OverlayBDBSConfig{
+		Lowers:     []snapshot.OverlayBDBSConfigLower{},
+		ResultFile: "",
+	}
+	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: overlaybdBaseLayer,
+	})
+	return &overlaybdBuilderEngine{
+		builderEngineBase: base,
+		overlaybdConfig:   config,
+		overlaybdLayers:   make([]specs.Descriptor, len(base.manifest.Layers)),
+	}
+}
+
+func (e *overlaybdBuilderEngine) downloadLayer(ctx context.Context, idx int) error {
+	desc := e.manifest.Layers[idx]
+	targetFile := path.Join(e.getLayerDir(idx), "layer.tar")
+	return downloadLayer(ctx, e.fetcher, targetFile, desc, true)
+}
+
+func (e *overlaybdBuilderEngine) buildLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	if err := prepareWritableLayer(ctx, layerDir); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
+		Data:  path.Join(layerDir, "writable_data"),
+		Index: path.Join(layerDir, "writable_index"),
+	}
+	if err := writeConfig(layerDir, e.overlaybdConfig); err != nil {
+		return err
+	}
+	if err := overlaybdApply(ctx, layerDir); err != nil {
+		return err
+	}
+	if err := overlaybdCommit(ctx, layerDir, commitFile); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: path.Join(layerDir, commitFile),
+	})
+	os.Remove(path.Join(layerDir, "layer.tar"))
+	os.Remove(path.Join(layerDir, "writable_data"))
+	os.Remove(path.Join(layerDir, "writable_index"))
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) uploadLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	desc, err := getFileDesc(path.Join(layerDir, commitFile), false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get descriptor for layer %d", idx)
+	}
+	desc.MediaType = images.MediaTypeDockerSchema2Layer
+	desc.Annotations = map[string]string{
+		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
+		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+	}
+	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, commitFile), desc); err != nil {
+		return errors.Wrapf(err, "failed to upload layer %d", idx)
+	}
+	e.overlaybdLayers[idx] = desc
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) uploadImage(ctx context.Context) error {
+	for idx := range e.manifest.Layers {
+		e.manifest.Layers[idx] = e.overlaybdLayers[idx]
+		e.config.RootFS.DiffIDs[idx] = e.overlaybdLayers[idx].Digest
+	}
+	baseDesc := specs.Descriptor{
+		MediaType: images.MediaTypeDockerSchema2Layer,
+		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+		Size:      4737695,
+		Annotations: map[string]string{
+			labelKeyOverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+			labelKeyOverlayBDBlobSize:   "4737695",
+		},
+	}
+	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {
+		return errors.Wrapf(err, "failed to upload baselayer %q", overlaybdBaseLayer)
+	}
+	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
+	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
+	return uploadManifestAndConfig(ctx, e.pusher, e.manifest, e.config)
+}
+
+func (e *overlaybdBuilderEngine) cleanup() {
+	os.RemoveAll(e.workDir)
+}
+
+func (e *overlaybdBuilderEngine) getLayerDir(idx int) string {
+	return path.Join(e.workDir, fmt.Sprintf("%04d_", idx)+e.manifest.Layers[idx].Digest.String())
+}
+
+func overlaybdApply(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-apply")
+
+	out, err := exec.CommandContext(ctx, binpath,
+		path.Join(dir, "layer.tar"),
+		path.Join(dir, "config.json")).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-apply: %s", out)
+	}
+	return nil
+}

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package builder
 
 import (

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -17,31 +17,11 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"os/signal"
-	"path"
-	"path/filepath"
-	"strings"
-	"sync"
 
-	"github.com/containerd/accelerated-container-image/pkg/snapshot"
-	"github.com/containerd/containerd/archive/compression"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/continuity"
-	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	"github.com/containerd/accelerated-container-image/cmd/convertor/builder"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -53,356 +33,56 @@ var (
 	tagInput  string
 	tagOutput string
 	dir       string
+	foci      bool
+	overlaybd bool
 
 	rootCmd = &cobra.Command{
 		Use:   "overlaybd-convertor",
 		Short: "An image conversion tool from oci image to overlaybd image.",
 		Long:  "overlaybd-convertor is a standalone userspace image conversion tool that helps converting oci images to overlaybd images",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := convert(); err != nil {
-				logrus.Errorf("run with error: %v", err)
-				os.Exit(1)
+			ctx := context.Background()
+			opt := builder.BuilderOptions{
+				Ref:       repo + ":" + tagInput,
+				TargetRef: repo + ":" + tagOutput,
+				Auth:      user,
+				PlainHTTP: plain,
+				WorkDir:   dir,
+			}
+			if !overlaybd && !foci {
+				overlaybd = true
+			}
+			if overlaybd {
+				logrus.Info("building overlaybd ...")
+				opt.Engine = builder.BuilderEngineTypeOverlayBD
+				builder, err := builder.NewOverlayBDBuilder(ctx, opt)
+				if err != nil {
+					logrus.Errorf("failed to create overlaybd builder: %v", err)
+					os.Exit(1)
+				}
+				if err := builder.Build(ctx); err != nil {
+					logrus.Errorf("failed to build overlaybd: %v", err)
+					os.Exit(1)
+				}
+				logrus.Info("overlaybd build finished")
+			}
+			if foci {
+				logrus.Info("building foci ...")
+				opt.Engine = builder.BuilderEngineTypeFOCI
+				builder, err := builder.NewOverlayBDBuilder(ctx, opt)
+				if err != nil {
+					logrus.Errorf("failed to create foci builder: %v", err)
+					os.Exit(1)
+				}
+				if err := builder.Build(ctx); err != nil {
+					logrus.Errorf("failed to build foci: %v", err)
+					os.Exit(1)
+				}
+				logrus.Info("foci build finished")
 			}
 		},
 	}
 )
-
-func prepareWritableLayer(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-create")
-	dataPath := path.Join(dir, "writable_data")
-	indexPath := path.Join(dir, "writable_index")
-	os.RemoveAll(dataPath)
-	os.RemoveAll(indexPath)
-	out, err := exec.CommandContext(ctx, binpath, "-s",
-		dataPath, indexPath, "64").CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to prepare writable layer: %s", out)
-	}
-	return nil
-}
-
-func writeConfig(dir string, configJSON *snapshot.OverlayBDBSConfig) error {
-	data, err := json.Marshal(configJSON)
-	if err != nil {
-		return err
-	}
-
-	confPath := path.Join(dir, "config.json")
-	if err := continuity.AtomicWriteFile(confPath, data, 0600); err != nil {
-		return err
-	}
-	return nil
-}
-
-func overlaybdApply(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-apply")
-
-	out, err := exec.CommandContext(ctx, binpath,
-		path.Join(dir, "layer.tar"),
-		path.Join(dir, "config.json")).CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to apply tar to overlaybd: %s", out)
-	}
-	return nil
-}
-
-func overlaybdCommit(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-commit")
-
-	out, err := exec.CommandContext(ctx, binpath, "-z",
-		path.Join(dir, "writable_data"),
-		path.Join(dir, "writable_index"),
-		path.Join(dir, "overlaybd.commit")).CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to commit overlaybd: %s", out)
-	}
-	return nil
-}
-
-func makeDesc(dir string) (specs.Descriptor, error) {
-	commitFile := path.Join(dir, "overlaybd.commit")
-	file, err := os.Open(commitFile)
-	if err != nil {
-		return specs.Descriptor{}, err
-	}
-	defer file.Close()
-
-	h := sha256.New()
-	size, err := io.Copy(h, file)
-	if err != nil {
-		return specs.Descriptor{}, err
-	}
-	dgst := digest.NewDigest(digest.SHA256, h)
-	return specs.Descriptor{
-		MediaType: images.MediaTypeDockerSchema2Layer,
-		Digest:    dgst,
-		Size:      size,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/overlaybd/blob-digest": dgst.String(),
-			"containerd.io/snapshot/overlaybd/blob-size":   fmt.Sprintf("%d", size),
-		},
-	}, nil
-}
-
-func uploadBlob(ctx context.Context, pusher remotes.Pusher, path string, desc specs.Descriptor) error {
-	cw, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			logrus.Infof("layer %s exists", desc.Digest.String())
-			return nil
-		}
-		return err
-	}
-
-	defer cw.Close()
-	fobd, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer fobd.Close()
-	if err = content.Copy(ctx, cw, fobd, desc.Size, desc.Digest); err != nil {
-		return err
-	}
-	return nil
-}
-
-func uploadBytes(ctx context.Context, pusher remotes.Pusher, desc specs.Descriptor, data []byte) error {
-	cw, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			logrus.Infof("content %s exists", desc.Digest.String())
-			return nil
-		}
-		return err
-	}
-	defer cw.Close()
-
-	err = content.Copy(ctx, cw, bytes.NewReader(data), desc.Size, desc.Digest)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert() error {
-	ctx := context.Background()
-	defer func() {
-		// clean temp data
-		os.RemoveAll(dir)
-	}()
-
-	resolver := docker.NewResolver(docker.ResolverOptions{
-		Credentials: func(s string) (string, string, error) {
-			if user == "" {
-				return "", "", nil
-			}
-			userSplit := strings.Split(user, ":")
-			return userSplit[0], userSplit[1], nil
-		},
-		PlainHTTP: plain,
-	})
-
-	ref := repo + ":" + tagInput
-	_, desc, err := resolver.Resolve(ctx, ref)
-	if err != nil {
-		return errors.Wrapf(err, "failed to resolve reference %q", ref)
-	}
-
-	fetcher, err := resolver.Fetcher(ctx, ref)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get fetcher for %q", ref)
-	}
-
-	targetRef := repo + ":" + tagOutput
-	pusher, err := resolver.Pusher(ctx, targetRef)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get pusher for %q", targetRef)
-	}
-
-	rc, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch manifest")
-	}
-	buf, err := io.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch manifest")
-	}
-	rc.Close()
-
-	manifest := specs.Manifest{}
-	err = json.Unmarshal(buf, &manifest)
-	if err != nil {
-		return err
-	}
-
-	rc, err = fetcher.Fetch(ctx, manifest.Config)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch config")
-	}
-	buf, err = io.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch config")
-	}
-	rc.Close()
-
-	config := specs.Image{}
-	if err = json.Unmarshal(buf, &config); err != nil {
-		return err
-	}
-
-	configJSON := snapshot.OverlayBDBSConfig{
-		Lowers:     []snapshot.OverlayBDBSConfigLower{},
-		ResultFile: "",
-	}
-	configJSON.Lowers = append(configJSON.Lowers, snapshot.OverlayBDBSConfigLower{
-		File: "/opt/overlaybd/baselayers/ext4_64",
-	})
-
-	results := make(chan error)
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(manifest.Layers))
-	for idx, layer := range manifest.Layers {
-		go func(idx int, layer specs.Descriptor) {
-			rc, err := fetcher.Fetch(ctx, layer)
-			if err != nil {
-				results <- errors.Wrapf(err, "failed to download for layer %d", idx)
-				return
-			}
-			drc, err := compression.DecompressStream(rc)
-			if err != nil {
-				results <- errors.Wrapf(err, "failed to decompress for layer %d", idx)
-				return
-			}
-			layerDir := path.Join(dir, fmt.Sprintf("%04d_", idx)+layer.Digest.String())
-			if err = os.MkdirAll(layerDir, 0644); err != nil {
-				results <- err
-				return
-			}
-			ftar, err := os.Create(path.Join(layerDir, "layer.tar"))
-			if err != nil {
-				results <- err
-				return
-			}
-			if _, err = io.Copy(ftar, drc); err != nil {
-				results <- errors.Wrapf(err, "failed to decompress copy for layer %d", idx)
-				return
-			}
-			logrus.Infof("downloaded layer %d, dir %s", idx, layerDir)
-			waitGroup.Done()
-		}(idx, layer)
-	}
-
-	waitGroup.Wait()
-	close(results)
-	for result := range results {
-		if result != nil {
-			return result
-		}
-	}
-
-	lastDigest := ""
-	for idx, layer := range manifest.Layers {
-		layerDir := path.Join(dir, fmt.Sprintf("%04d_", idx)+layer.Digest.String())
-		// TODO check diffID
-
-		// make writable layer
-		if err = prepareWritableLayer(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd create for layer %d", idx)
-		}
-
-		// make config
-		if idx > 0 {
-			configJSON.Lowers = append(configJSON.Lowers, snapshot.OverlayBDBSConfigLower{
-				File: path.Join(dir, lastDigest, "overlaybd.commit"),
-			})
-		}
-		configJSON.Upper = snapshot.OverlayBDBSConfigUpper{
-			Data:  path.Join(layerDir, "writable_data"),
-			Index: path.Join(layerDir, "writable_index"),
-		}
-		if err = writeConfig(layerDir, &configJSON); err != nil {
-			return err
-		}
-
-		// apply and commit
-		if err = overlaybdApply(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd apply for layer %d", idx)
-		}
-		if err = overlaybdCommit(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd commit for layer %d", idx)
-		}
-		//for test
-		// os.Rename(path.Join(layerDir, "layer.tar"), path.Join(layerDir, "overlaybd.commit"))
-
-		//calc digest
-		desc, err := makeDesc(layerDir)
-		if err != nil {
-			return errors.Wrapf(err, "failed to make descriptor for layer %d", idx)
-		}
-
-		// upload
-		if err = uploadBlob(ctx, pusher, path.Join(layerDir, "overlaybd.commit"), desc); err != nil {
-			return errors.Wrapf(err, "failed to upload layer %d", idx)
-		}
-		logrus.Infof("layer %d uploaded", idx)
-
-		lastDigest = fmt.Sprintf("%04d_", idx) + manifest.Layers[idx].Digest.String()
-		manifest.Layers[idx] = desc
-		config.RootFS.DiffIDs[idx] = desc.Digest
-
-		// clean unused file
-		os.Remove(path.Join(dir, lastDigest, "layer.tar"))
-		os.Remove(path.Join(dir, lastDigest, "writable_data"))
-		os.Remove(path.Join(dir, lastDigest, "writable_index"))
-	}
-
-	// add baselayer
-	baseDesc := specs.Descriptor{
-		MediaType: images.MediaTypeDockerSchema2Layer,
-		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-		Size:      4737695,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/overlaybd/blob-digest": "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-			"containerd.io/snapshot/overlaybd/blob-size":   "4737695",
-		},
-	}
-	if err = uploadBlob(ctx, pusher, "/opt/overlaybd/baselayers/ext4_64", baseDesc); err != nil {
-		return errors.Wrapf(err, "failed to upload baselayer")
-	}
-	manifest.Layers = append([]specs.Descriptor{baseDesc}, manifest.Layers...)
-	config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, config.RootFS.DiffIDs...)
-
-	// upload config and manifest
-	cbuf, err := json.Marshal(config)
-	if err != nil {
-		return err
-	}
-	manifest.Config = specs.Descriptor{
-		MediaType: images.MediaTypeDockerSchema2Config,
-		Digest:    digest.FromBytes(cbuf),
-		Size:      (int64)(len(cbuf)),
-	}
-	if err = uploadBytes(ctx, pusher, manifest.Config, cbuf); err != nil {
-		return errors.Wrapf(err, "failed to upload config")
-	}
-
-	cbuf, err = json.Marshal(manifest)
-	if err != nil {
-		return err
-	}
-	manifestDesc := specs.Descriptor{
-		MediaType: images.MediaTypeDockerSchema2Manifest,
-		Digest:    digest.FromBytes(cbuf),
-		Size:      (int64)(len(cbuf)),
-	}
-
-	if err = uploadBytes(ctx, pusher, manifestDesc, cbuf); err != nil {
-		return errors.Wrapf(err, "failed to upload manifest")
-	}
-	logrus.Infof("convert finished")
-
-	return nil
-}
 
 func init() {
 	rootCmd.Flags().SortFlags = false
@@ -412,6 +92,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&tagInput, "input-tag", "i", "", "tag for image converting from (required)")
 	rootCmd.Flags().StringVarP(&tagOutput, "output-tag", "o", "", "tag for image converting to (required)")
 	rootCmd.Flags().StringVarP(&dir, "dir", "d", "tmp_conv", "directory used for temporary data")
+	rootCmd.Flags().BoolVarP(&foci, "foci", "", false, "build foci format")
+	rootCmd.Flags().BoolVarP(&overlaybd, "overlaybd", "", false, "build overlaybd format")
 
 	rootCmd.MarkFlagRequired("repository")
 	rootCmd.MarkFlagRequired("input-tag")

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -33,7 +33,7 @@ var (
 	tagInput  string
 	tagOutput string
 	dir       string
-	foci      string
+	fastoci   string
 	overlaybd string
 
 	rootCmd = &cobra.Command{
@@ -41,9 +41,9 @@ var (
 		Short: "An image conversion tool from oci image to overlaybd image.",
 		Long:  "overlaybd-convertor is a standalone userspace image conversion tool that helps converting oci images to overlaybd images",
 		Run: func(cmd *cobra.Command, args []string) {
-			if overlaybd == "" && foci == "" {
+			if overlaybd == "" && fastoci == "" {
 				if tagOutput == "" {
-					logrus.Error("output-tag is required, you can specify it by [-o|--overlaybd|--foci]")
+					logrus.Error("output-tag is required, you can specify it by [-o|--overlaybd|--fastoci]")
 					os.Exit(1)
 				}
 				overlaybd = tagOutput
@@ -71,20 +71,20 @@ var (
 				}
 				logrus.Info("overlaybd build finished")
 			}
-			if foci != "" {
-				logrus.Info("building foci ...")
-				opt.Engine = builder.BuilderEngineTypeFOCI
-				opt.TargetRef = repo + ":" + foci
+			if fastoci != "" {
+				logrus.Info("building fastoci ...")
+				opt.Engine = builder.BuilderEngineTypeFastOCI
+				opt.TargetRef = repo + ":" + fastoci
 				builder, err := builder.NewOverlayBDBuilder(ctx, opt)
 				if err != nil {
-					logrus.Errorf("failed to create foci builder: %v", err)
+					logrus.Errorf("failed to create fastoci builder: %v", err)
 					os.Exit(1)
 				}
 				if err := builder.Build(ctx); err != nil {
-					logrus.Errorf("failed to build foci: %v", err)
+					logrus.Errorf("failed to build fastoci: %v", err)
 					os.Exit(1)
 				}
-				logrus.Info("foci build finished")
+				logrus.Info("fastoci build finished")
 			}
 		},
 	}
@@ -98,7 +98,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&tagInput, "input-tag", "i", "", "tag for image converting from (required)")
 	rootCmd.Flags().StringVarP(&tagOutput, "output-tag", "o", "", "tag for image converting to (required)")
 	rootCmd.Flags().StringVarP(&dir, "dir", "d", "tmp_conv", "directory used for temporary data")
-	rootCmd.Flags().StringVar(&foci, "foci", "", "build foci format")
+	rootCmd.Flags().StringVar(&fastoci, "fastoci", "", "build fastoci format")
 	rootCmd.Flags().StringVar(&overlaybd, "overlaybd", "", "build overlaybd format")
 
 	rootCmd.MarkFlagRequired("repository")

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -72,10 +72,12 @@ type OverlayBDBSConfig struct {
 
 // OverlayBDBSConfigLower
 type OverlayBDBSConfigLower struct {
-	File   string `json:"file,omitempty"`
-	Digest string `json:"digest,omitempty"`
-	Size   int64  `json:"size,omitempty"`
-	Dir    string `json:"dir,omitempty"`
+	DataFile   string `json:"dataFile,omitempty"`
+	DataDigest string `json:"dataDigest,omitempty"`
+	File       string `json:"file,omitempty"`
+	Digest     string `json:"digest,omitempty"`
+	Size       int64  `json:"size,omitempty"`
+	Dir        string `json:"dir,omitempty"`
 }
 
 type OverlayBDBSConfigUpper struct {


### PR DESCRIPTION
```
# backward compatibility: old usage still work, which will build overlaybd
bin/convertor -r <repo> -i <input-tag> -o <overlaybd-tag>

# build fastoci
bin/convertor -r <repo> -i <input-tag> --fastoci <fastoci-tag>

# build overlaybd
bin/convertor -r <repo> -i <input-tag> --overlaybd <overlaybd-tag>

# build both fastoci and overlaybd in one task
bin/convertor -r <repo> -i <input-tag> --fastoci <fastoci-tag> --overlaybd <overlaybd-tag>
```